### PR TITLE
[pcpp][express][2/x] Added data models, populate and getComparable functions for Hard Drives, Power Supplies, and Cases

### DIFF
--- a/server/models/part_models/CaseModel.js
+++ b/server/models/part_models/CaseModel.js
@@ -1,0 +1,17 @@
+const mongoose = require('../../Mongoose.js')
+
+const CaseSchema = new mongoose.Schema({
+    type: String,
+    model: String,
+    brand: String,
+    form_factor: String,
+    color: String,
+    external_bays: Number,
+    internal_bays: Number,
+    psu_wattage: Number,
+    side_panel: String,
+})
+
+const CaseModel = mongoose.model('Case', CaseSchema, 'case')
+
+module.exports = CaseModel

--- a/server/models/part_models/ComponentTypesEnum.js
+++ b/server/models/part_models/ComponentTypesEnum.js
@@ -3,7 +3,7 @@ const ComponentTypes = Object.freeze({
     VIDEOCARD: 'video-card',
     MOTHERBOARD: 'motherboard',
     MEMORY: 'memory',
-    INTERNAL_HARD_DRIVE: 'internal-hard-drive',
+    HARD_DRIVE: 'hard-drive',
     POWER_SUPPLY: 'power-supply',
     CASE: 'case',
     UNKNOWN: 'uknown',

--- a/server/models/part_models/HardDriveModel.js
+++ b/server/models/part_models/HardDriveModel.js
@@ -1,0 +1,16 @@
+const mongoose = require('../../Mongoose.js')
+
+const HardDriveSchema = new mongoose.Schema({
+    type: String,
+    model: String,
+    brand: String,
+    capacity: Number,
+    price_per_gb: Number,
+    storage_type: String,
+    form_factor: String,
+    interface: String,
+})
+
+const HardDriveModel = mongoose.model('HardDrive', HardDriveSchema, 'hard-drive')
+
+module.exports = HardDriveModel

--- a/server/models/part_models/PowerSupplyModel.js
+++ b/server/models/part_models/PowerSupplyModel.js
@@ -1,0 +1,15 @@
+const mongoose = require('../../Mongoose.js')
+
+const PowerSupplySchema = new mongoose.Schema({
+    type: String,
+    model: String,
+    brand: String,
+    form_factor: String,
+    efficiency_rating: String,
+    wattage: Number,
+    modular: String,
+})
+
+const PowerSupplyModel = mongoose.model('PowerSupply', PowerSupplySchema, 'power-supply')
+
+module.exports = PowerSupplyModel

--- a/server/tests/parts/ComparablePartsTests.js
+++ b/server/tests/parts/ComparablePartsTests.js
@@ -1,4 +1,4 @@
-const { test_cpu, test_videocard, test_motherboard, test_memory } = require('../../utils/parts/test_parts.js')
+const { test_cpu, test_videocard, test_motherboard, test_memory, test_hard_drive, test_power_supply, test_case } = require('./test_parts.js')
 const { getComparableParts } = require('../../utils/parts/ComparableParts.js')
 
 const getComparableCPUs_test = async () => {
@@ -45,11 +45,47 @@ const getComparableMemorys_test = async () => {
     }
 }
 
+const getComparableHardDrives_test = async () => {
+    const comparableHardDrives = await getComparableParts(test_hard_drive)
+    if (comparableHardDrives.length > 0) {
+        console.log("getComparableParts_test-HardDrive: Passed")
+        return true
+    } else {
+        console.log("getComparableParts_test-HardDrive: Failed")
+        return false
+    }
+}
+
+const getComparablePowerSupplys_test = async () => {
+    const comparablePowerSupplys = await getComparableParts(test_power_supply)
+    if (comparablePowerSupplys.length > 0) {
+        console.log("getComparableParts_test-PowerSupply: Passed")
+        return true
+    } else {
+        console.log("getComparableParts_test-PowerSupply: Failed")
+        return false
+    }
+}
+
+const getComparableCases_test = async () => {
+    const comparableCases = await getComparableParts(test_case)
+    if (comparableCases.length > 0) {
+        console.log("getComparableParts_test-Case: Passed")
+        return true
+    } else {
+        console.log("getComparableParts_test-Case: Failed")
+        return false
+    }
+}
+
 const getComparableParts_test = async () => {
     await getComparableCPUs_test()
     await getComparableVideoCards_test()
     await getComparableMotherboards_test()
     await getComparableMemorys_test()
+    await getComparableHardDrives_test()
+    await getComparablePowerSupplys_test()
+    await getComparableCases_test()
 }
 
 const running_tests = async () => {

--- a/server/tests/parts/test_parts.js
+++ b/server/tests/parts/test_parts.js
@@ -55,4 +55,50 @@ const test_memory = {
 "price_per_gb": 0
 }
 
-module.exports = { test_cpu, test_videocard, test_motherboard, test_memory }
+const test_hard_drive = {
+"_id": {
+"$oid": "6864135c5e0e2c0734003763"
+},
+"type": "hard-drive",
+"model": "Premier SP550",
+"brand": "ADATA",
+"capacity":240000000000,
+"price_per_gb": 0,
+"storage_type": "SSD",
+"form_factor": "M.2-2280",
+"interface": "M.2 (B+M)",
+"platter_rpm": "none",
+"cache_amount": "none"
+}
+
+const test_power_supply = {
+"_id": {
+"$oid": "68641802e6f7d23c9a87e6df"
+},
+"type": "power-supply",
+"model": "XPG CORE Reactor",
+"brand": "ADATA",
+"form_factor": "ATX",
+"efficiency_rating": "80+ Gold",
+"wattage": 850,
+"modular": "Full"
+}
+
+const test_case = {
+"_id": {
+"$oid": "68641b49f77b006649fd92a2"
+},
+"type": "case",
+"model": "400C",
+"brand": "Corsair",
+"form_factor": "ATX Mid Tower",
+"color": "White",
+"external_bays": 0,
+"internal_bays": 2,
+"psu_wattage": 0,
+"side_panel": "none"
+}
+
+
+
+module.exports = { test_cpu, test_videocard, test_motherboard, test_memory, test_hard_drive, test_power_supply, test_case }

--- a/server/utils/parts/ComparableParts.js
+++ b/server/utils/parts/ComparableParts.js
@@ -161,14 +161,14 @@ const getComparableParts = async (part) => {
             return await getComparableMotherboards(part, margin)
         case ComponentTypes.MEMORY:
             return await getComparableMemorys(part, margin)
-        case 'hard-drive':
+        case ComponentTypes.HARD_DRIVE:
             return await getComparableHardDrives(part, margin)
-        case 'power-supply':
+        case ComponentTypes.POWER_SUPPLY:
             return await getComparablePowerSupplys(part, margin)
-        case 'case':
+        case ComponentTypes.CASE:
             return await getComparableCases(part, margin)
         case ComponentTypes.UNKNOWN:
-            console.log("ComponentType: UKNOWN in get comparable parts")
+            console.log("ComponentType: UNKNOWN in get comparable parts")
             return []
     }
     return []

--- a/server/utils/parts/ComparableParts.js
+++ b/server/utils/parts/ComparableParts.js
@@ -2,24 +2,28 @@ const CPUModel = require('../../models/part_models/CPUModel.js')
 const VideoCardModel = require('../../models/part_models/VideoCardModel.js')
 const MotherboardModel = require('../../models/part_models/MotherboardModel.js')
 const MemoryModel = require('../../models/part_models/MemoryModel.js')
+const HardDriveModel = require('../../models/part_models/HardDriveModel.js')
+const PowerSupplyModel = require('../../models/part_models/PowerSupplyModel.js')
+const CaseModel = require('../../models/part_models/CaseModel.js')
 
-const getLow = (value, margin) => {
+
+const calcLow = (value, margin) => {
     return Number(Math.floor(value - value * margin))
 }
 
-const getHigh = (value, margin) => {
+const calcHigh = (value, margin) => {
     return Number(Math.ceil(value + value * margin))
 }
 
 const getComparableCPUs = async (cpu, margin) => {
-    const comparableCoresLow = getLow(cpu.cores, margin)
-    const comparableCoresHigh = getHigh(cpu.cores, margin)
+    const comparableCoresLow = calcLow(cpu.cores, margin)
+    const comparableCoresHigh = calcHigh(cpu.cores, margin)
     
-    const comparableBaseClockLow = getLow(cpu.base_clock, margin)
-    const comparableBaseClockHigh = getHigh(cpu.base_clock, margin)
+    const comparableBaseClockLow = calcLow(cpu.base_clock, margin)
+    const comparableBaseClockHigh = calcHigh(cpu.base_clock, margin)
 
-    const comparableBoostClockLow = getLow(cpu.boost_clock, margin)
-    const comparableBoostClockHigh = getHigh(cpu.boost_clock, margin)
+    const comparableBoostClockLow = calcLow(cpu.boost_clock, margin)
+    const comparableBoostClockHigh = calcHigh(cpu.boost_clock, margin)
     
     const comparableCPUs = await CPUModel.find( { 
         $and: [
@@ -31,18 +35,19 @@ const getComparableCPUs = async (cpu, margin) => {
             { boost_clock: {$gte: comparableBoostClockLow} },
         ]
     } )
+
     return comparableCPUs
 }
 
 const getComparableVideoCards = async (videocard, margin) => {
-    const comparableVramLow = getLow(videocard.vram, margin)
-    const comparableVramHigh = getHigh(videocard.vram, margin)
+    const comparableVramLow = calcLow(videocard.vram, margin)
+    const comparableVramHigh = calcHigh(videocard.vram, margin)
     
-    const comparableBaseClockLow = getLow(videocard.base_clock, margin)
-    const comparableBaseClockHigh = getHigh(videocard.base_clock, margin)
+    const comparableBaseClockLow = calcLow(videocard.base_clock, margin)
+    const comparableBaseClockHigh = calcHigh(videocard.base_clock, margin)
     
-    const comparableBoostClockLow = getLow(videocard.boost_clock, margin)
-    const comparableBoostClockHigh = getHigh(videocard.boost_clock, margin)
+    const comparableBoostClockLow = calcLow(videocard.boost_clock, margin)
+    const comparableBoostClockHigh = calcHigh(videocard.boost_clock, margin)
     
     const comparableVideoCards = await VideoCardModel.find( { 
         $and: [
@@ -58,11 +63,11 @@ const getComparableVideoCards = async (videocard, margin) => {
 }
 
 const getComparableMotherboards = async (motherboard, margin) => {
-    const comparableRamSlotsLow = getLow(motherboard.ram_slots, margin)
-    const comparableRamSlotsHigh = getHigh(motherboard.ram_slots, margin)
+    const comparableRamSlotsLow = calcLow(motherboard.ram_slots, margin)
+    const comparableRamSlotsHigh = calcHigh(motherboard.ram_slots, margin)
     
-    const comparableMaxRamLow = getLow(motherboard.max_ram, margin)
-    const comparableMaxRamHigh = getHigh(motherboard.max_ram, margin)
+    const comparableMaxRamLow = calcLow(motherboard.max_ram, margin)
+    const comparableMaxRamHigh = calcHigh(motherboard.max_ram, margin)
     
     const comparableMotherboards = await MotherboardModel.find( { 
         $and: [
@@ -78,17 +83,11 @@ const getComparableMotherboards = async (motherboard, margin) => {
 }
 
 const getComparableMemorys = async (memory, margin) => {
-    const comparableSpeedLow = getLow(memory.speed, margin)
-    const comparableSpeedHigh = getHigh(memory.speed, margin)
+    const comparableSpeedLow = calcLow(memory.speed, margin)
+    const comparableSpeedHigh = calcHigh(memory.speed, margin)
 
-    const comparableTotalSizeLow = getLow(memory.total_size, margin)
-    const comparableTotalSizeHigh = getHigh(memory.total_size, margin)
-
-    console.log(comparableSpeedLow)
-    console.log(comparableSpeedHigh)
-
-    console.log(comparableTotalSizeLow)
-    console.log(comparableTotalSizeHigh)
+    const comparableTotalSizeLow = calcLow(memory.total_size, margin)
+    const comparableTotalSizeHigh = calcHigh(memory.total_size, margin)
     
     const comparableMemorys = await MemoryModel.find( { 
         $and: [
@@ -102,6 +101,54 @@ const getComparableMemorys = async (memory, margin) => {
     return comparableMemorys
 }
 
+const getComparableHardDrives = async (hard_drive, margin) => {
+    const comparableCapacityLow = calcLow(hard_drive.capacity, margin)
+    const comparableCapacityHigh = calcHigh(hard_drive.capacity, margin)
+    
+    const comparableHardDrives = await HardDriveModel.find( { 
+        $and: [
+            { capacity: {$lte: comparableCapacityHigh} },
+            { capacity: {$gte: comparableCapacityLow} },
+            { storage_type: hard_drive.storage_type },
+            { form_factor: hard_drive.form_factor },
+            { interface: hard_drive.interface },
+        ]
+    } )
+    return comparableHardDrives
+}
+
+const getComparablePowerSupplys = async (power_supply, margin) => {
+    const comparableWattageLow = calcLow(power_supply.wattage, margin)
+    const comparableWattageHigh = calcHigh(power_supply.wattage, margin)
+    
+    const comparablePowerSupplys = await PowerSupplyModel.find( { 
+        $and: [
+            { wattage: {$lte: comparableWattageHigh} },
+            { wattage: {$gte: comparableWattageLow} },
+            { form_factor: power_supply.form_factor },
+            { efficiency_rating: power_supply.efficiency_rating },
+            { modular: power_supply.modular },
+        ]
+    } )
+    return comparablePowerSupplys
+}
+
+const getComparableCases = async (input_case, margin) => {    
+    const comparableInternalBaysLow = calcLow(input_case.internal_bays, margin)
+    const comparableInternalBaysHigh = calcHigh(input_case.internal_bays, margin)
+
+    const comparableCases = await CaseModel.find( { 
+        $and: [
+            { internal_bays: {$lte: comparableInternalBaysHigh} },
+            { internal_bays: {$gte: comparableInternalBaysLow} },
+            { form_factor: input_case.form_factor },
+            { color: input_case.color },
+        ]
+    } )
+    return comparableCases
+}
+
+
 const getComparableParts = async (part) => {
     const margin = 0.1
     switch (part.type) {
@@ -113,12 +160,14 @@ const getComparableParts = async (part) => {
             return await getComparableMotherboards(part, margin)
         case 'memory':
             return await getComparableMemorys(part, margin)
+        case 'hard-drive':
+            return await getComparableHardDrives(part, margin)
+        case 'power-supply':
+            return await getComparablePowerSupplys(part, margin)
+        case 'case':
+            return await getComparableCases(part, margin)
     }
     return []
 }
-
-const { test_cpu, test_videocard, test_motherboard, test_memory } = require('./test_parts.js')
-
-getComparableParts(test_memory)
 
 module.exports = { getComparableParts }

--- a/server/utils/pcpartpicker/populate.py
+++ b/server/utils/pcpartpicker/populate.py
@@ -46,7 +46,7 @@ def populate_cpus():
         print(f'cpu_id: {cpu_id} inserted into cpu collection')
     print(f'{cpu_count} cpu parts added to database')
 
-def populate_videocards():
+def populate_video_cards():
     api = API()
     videocard_data = api.retrieve("video-card")["video-card"]
 
@@ -131,10 +131,104 @@ def populate_memorys():
         print(f'memory_id: {memory_id} inserted into memory collection')
     print(f'{memory_count} memory parts added to database')
 
+def populate_hard_drives():
+    api = API()
+    hard_drive_data = api.retrieve("internal-hard-drive")["internal-hard-drive"]
+
+    hard_drive_collection = remakeCollection("hard-drive")
+    hard_drive_count = 0
+    
+    for hard_drive in hard_drive_data:
+        hard_drive_doc = {
+            "type": "hard-drive",
+            "model": hard_drive.model,
+            "brand": hard_drive.brand,
+            "capacity": hard_drive.capacity.total,
+            "price_per_gb": float(hard_drive.price_per_gb.amount),
+            "storage_type": hard_drive.storage_type,
+            "form_factor": hard_drive.form_factor,
+            "interface": hard_drive.interface,
+        }
+
+        if hard_drive.platter_rpm:
+            hard_drive_doc["platter_rpm"] = hard_drive.platter_rpm
+        else:
+            hard_drive_doc["platter_rpm"] = "none"
+
+        if hard_drive.cache_amount:
+            hard_drive_doc["cache_amount"] = hard_drive.cache_amount.total
+        else:
+            hard_drive_doc["cache_amount"] = "none"
+
+
+        hard_drive_count += 1
+        hard_drive_id = hard_drive_collection.insert_one(hard_drive_doc).inserted_id
+        print(f'hard_drive_id: {hard_drive_id} inserted into hard_drive collection')
+    print(f'{hard_drive_count} hard_drive parts added to database')
+
+def populate_power_supplys():
+    api = API()
+    power_supply_data = api.retrieve("power-supply")["power-supply"]
+
+    power_supply_collection = remakeCollection("power-supply")
+    power_supply_count = 0
+
+    for power_supply in power_supply_data:
+        power_supply_doc = {
+            "type": "power-supply",
+            "model": power_supply.model,
+            "brand": power_supply.brand,
+            "form_factor": power_supply.form_factor,
+            "efficiency_rating": power_supply.efficiency_rating,
+            "wattage": power_supply.wattage,
+            "modular": power_supply.modular,
+        }
+
+        power_supply_count += 1
+        power_supply_id = power_supply_collection.insert_one(power_supply_doc).inserted_id
+        print(f'power_supply_id: {power_supply_id} inserted into power_supply collection')
+    print(f'{power_supply_count} power_supply parts added to database')
+
+def populate_cases():
+    api = API()
+    case_data = api.retrieve("case")["case"]
+
+    case_collection = remakeCollection("case")
+    case_count = 0
+
+    for case in case_data:
+        case_doc = {
+            "type": "case",
+            "model": case.model,
+            "brand": case.brand,
+            "form_factor": case.form_factor,
+            "color": case.color,
+            "external_bays": case.external_bays,
+            "internal_bays": case.internal_bays,
+        }
+
+        if case.psu_wattage:
+            case_doc["psu_wattage"] = case.psu_wattage
+        else:
+            case_doc["psu_wattage"] = 0
+        
+        if case.side_panel:
+            case_doc["side_panel"] = case.side_panel
+        else:
+            case_doc["side_panel"] = "none"
+
+        case_count += 1
+        case_id = case_collection.insert_one(case_doc).inserted_id
+        print(f'case_id: {case_id} inserted into case collection')
+    print(f'{case_count} case parts added to database')
+
 def populate_parts_database():
     populate_cpus()
-    populate_videocards()
+    populate_video_cards()
     populate_motherboards()
     populate_memorys()
+    populate_hard_drives()
+    populate_power_supplys()
+    populate_cases()
 
 populate_parts_database()


### PR DESCRIPTION
### Summary
In utils/pcpartpicker/populate.py:
Added populate function for hard drive to populate database with fresh hard drive data from PCPartPicker
Added populate function for power supply to populate database with fresh power supply from PCPartPicker
Added populate function for case to populate database with fresh case data from PCPartPicker

In utils/parts/ComparableParts.js:
Added getComparableHardDrives function to grab hard drives comparable to input hard drive from database
Added getComparablePowerSupplys function to grab power supplies comparable to input power supply from database
Added getComparableCases function to grab cases comparable to input case from database

The flow will be user inputs specs for a component type, comparable components are retrieved, comparable components are analyzed to find recommended value of input component.
This code stocks the database of comparable components and has the util functions to find comparable components for hard drives, power supplies, and cases.

To answer questions from last PR:
The reason development went data model -> populate -> getComparable instead of making all of the data models and then all of the populates and then all of the getComparable functions was due to typing errors between Python/MongoDB/Node.js making abstraction difficult and potentially confusing if it was discovered that a certain type conversion wasn't compatible once everything had been developed.
As a result, goal was end to end on every component type before moving onto the next.

### Data Models
|Hard Drive Model|Power Supply Model|Case Model|
|---|---|---|
|type: String|type: String|type: String|
|model: String|model: String|model: String|
|brand: String|brand: String|brand: String|
|capacity: Number|form_factor: String|form_factor: String|
|price_per_gb: Number|efficiency_rating: String|color: String|
|storage_type: String|wattage: Number|external_bays: Number|
|form_factor: String|modular: string|internal_bays: Number|
|interface: String| |psu_wattage: Number|
| | |side_panel: String|

For hard drive, price_per_gb is currently unused but will likely be considered for build recommender.
For case, color, external bays, and psu_wattage are currently unused but will likely be considered for build recommender.

### Tests
|before populate_hard_drives.py|after populate_hard_drives.py|
|---|---|
|<img width="1413" alt="image" src="https://github.com/user-attachments/assets/a602d5d3-ba0d-494b-8840-ec06997ccdd2" />|<img width="1420" alt="image" src="https://github.com/user-attachments/assets/cfba3103-c2d4-4503-a90e-07a88cd55ba6" />|

|before populate_power_supplys.py|after populate_power_supplys.py|
|---|---|
|<img width="1413" alt="image" src="https://github.com/user-attachments/assets/a602d5d3-ba0d-494b-8840-ec06997ccdd2" />|<img width="1415" alt="image" src="https://github.com/user-attachments/assets/4607509e-acf1-4621-9a6e-486437a9a5d8" />|

|before populate_cases.py|after populate_cases.py|
|---|---|
|<img width="1413" alt="image" src="https://github.com/user-attachments/assets/a602d5d3-ba0d-494b-8840-ec06997ccdd2" />|<img width="1420" alt="image" src="https://github.com/user-attachments/assets/f7c740ed-d4b5-4249-bec2-f1c7f774ac16" />|

|getComparableHardDrives test|
|---|
|<img width="553" alt="image" src="https://github.com/user-attachments/assets/0ce99143-2df2-473f-9298-36749de15b1e" />|

|getComparablePowerSupplys test|
|---|
|<img width="580" alt="image" src="https://github.com/user-attachments/assets/044c12c0-bf96-4303-af1a-e34dd6349387" />|

|getComparableCases test|
|<img width="462" alt="image" src="https://github.com/user-attachments/assets/8536f1ea-2707-40d9-884c-b0dc777b3b52" />|

|running getComparable tests|
|---|
|<img width="314" alt="image" src="https://github.com/user-attachments/assets/8ddb37f5-b4fb-4a69-874a-2c30eea0900f" />|
