### PR TITLE
[evaluate][express][2/x] Fixed ebayPriceToNumber failing $xx.xx to $xx.xx pricing, removed outlier listings with IQR, fixed Ebay similar results polluting data

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "client",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/server/models/part_models/ComponentPropertiesEnums.js
+++ b/server/models/part_models/ComponentPropertiesEnums.js
@@ -1,0 +1,81 @@
+const CPU_PROPERTIES = Object.freeze({
+    TYPE: 'cpu',
+    MODEL: 'model',
+    BRAND: 'brand',
+    CORES: 'cores',
+    BASE_CLOCK: 'base_clock',
+    BOOST_CLOCK: 'boost_clock',
+    MULTI_THREADING: 'multithreading',
+    INTEGRATED_GRAPHICS: 'integrated_graphics'
+});
+
+const VIDEOCARD_PROPERTIES = Object.freeze({
+    TYPE: 'video-card',
+    MODEL: 'model',
+    BRAND: 'brand',
+    CHIPSET: 'chipset',
+    VRAM: 'vram',
+    BASE_CLOCK: 'base_clock',
+    BOOST_CLOCK: 'boost_clock',
+});
+
+const MOTHERBOARD_PROPERTIES = Object.freeze({
+    TYPE: 'motherboard',
+    MODEL: 'model',
+    BRAND: 'brand',
+    SOCKET: 'socket',
+    FORM_FACTOR: 'form_factor',
+    RAM_SLOTS: 'ram_slots',
+    MAX_RAM: 'max_ram',
+});
+
+const MEMORY_PROPERTIES = Object.freeze({
+    TYPE: 'memory',
+    MODEL: 'model',
+    BRAND: 'brand',
+    MODULE_TYPE: 'module_type',
+    SPEED: 'speed',
+    NUMBER_OF_MODULES: 'number_of_modules',
+    MODULE_SIZE: 'module_size',
+    TOTAL_SIZE: 'total_size',
+    FIRST_WORD_LATENCY: 'first_word_latency',
+    CAS_TIMING: 'cas_timing',
+    PRICE_PER_GB: 'price_per_gb',
+});
+
+const HARD_DRIVE_PROPERTIES = Object.freeze({
+    TYPE: 'hard-drive',
+    MODEL: 'model',
+    BRAND: 'brand',
+    CAPACITY: 'capacity',
+    PRICE_PER_GB: 'price_per_gb',
+    STORAGE_TYPE: 'storage_type',
+    FORM_FACTOR: 'form_factor',
+    INTERFACE: 'interface',
+    PLATTER_RPM: 'platter_rpm',
+    CACHE_AMOUNT: 'cache_amount',
+});
+
+const POWER_SUPPLY_PROPERTIES = Object.freeze({
+    TYPE: 'power-supply',
+    MODEL: 'model',
+    BRAND: 'brand',
+    FORM_FACTOR: 'form_factor',
+    EFFICIENCY_RATING: 'efficiency_rating',
+    WATTAGE: 'wattage',
+    MODULAR: "modular",
+});
+
+const CASE_PROPERTIES = Object.freeze({
+    TYPE: 'case',
+    MODEL: 'model',
+    BRAND: 'brand',
+    FORM_FACTOR: 'form_factor',
+    COLOR: 'color',
+    INTERNAL_BAYS: 'internal_bays',
+    EXTERNAL_BAYS: "external_bays",
+    PSU_WATTAGE: 'psu_wattage',
+    SIDE_PANEL: 'side_panel',
+});
+
+module.exports = { CPU_PROPERTIES, VIDEOCARD_PROPERTIES, MOTHERBOARD_PROPERTIES, MEMORY_PROPERTIES, HARD_DRIVE_PROPERTIES, POWER_SUPPLY_PROPERTIES, CASE_PROPERTIES}

--- a/server/tests/parts/EbayScraperTests.js
+++ b/server/tests/parts/EbayScraperTests.js
@@ -1,5 +1,5 @@
 const { TestError } = require("../../errors/TestError")
-const getRecentlySoldListings = require("../../utils/ebay/EbayScraper")
+const { getRecentlySoldListings } = require("../../utils/ebay/EbayScraper")
 
 const getRecentlySoldListings_test = async () => {
     const recentlySoldListings = await getRecentlySoldListings("2070super", 3)

--- a/server/tests/parts/EvaluationsTests.js
+++ b/server/tests/parts/EvaluationsTests.js
@@ -1,0 +1,174 @@
+const { ebayDateToJSDate, ebayPriceToNumber } = require('../../utils/ebay/EbayScraper.js')
+const { evaluatePart, removePriceOutliers } = require('../../utils/parts/EvaluateParts.js')
+const { TestError } = require('../../errors/TestError.js')
+const outlier_test_listings = [
+    {
+    title: 'EVGA GeForce RTX 2070 XC ULTRA GAMING 8GB GDDR6 Graphics Card rgb ray tracing',
+    sold_date: '2025-06-28T07:00:00.000Z',
+    sold_price: 2
+    },
+    {
+    title: 'NVIDIA GeForce RTX 2070 Super GDDR6 Graphics Card - 8GB',
+    sold_date: '2025-06-28T07:00:00.000Z',
+    sold_price: 242.5
+    },
+    {
+    title: 'ZOTAC   RTX 2070 SUPER  8GB NO WORKING Graphics Card',
+    sold_date: '2025-06-28T07:00:00.000Z',
+    sold_price: 46
+    },
+    {
+    title: 'ASUS ROG Strix GeForce RTX 2070 OC 08G Gaming Brand New Open Box',
+    sold_date: '2025-06-28T07:00:00.000Z',
+    sold_price: 219.99
+    },
+    {
+    title: 'MSI NVIDIA GeForce RTX 2070 SUPER ',
+    sold_date: '2025-06-28T07:00:00.000Z',
+    sold_price: 200
+    },
+    {
+    title: 'EVGA NVIDIA GeForce RTX 2070 Super Black 8GB GDDR6 Graphics Card',
+    sold_date: '2025-06-27T07:00:00.000Z',
+    sold_price: 175.79
+    },
+    {
+    title: 'ASUS Dual  RTX 2070 SUPER 8GB GDDR6 Graphics Card',
+    sold_date: '2024-11-29T08:00:00.000Z',
+    sold_price: 190
+    },
+    {
+    title: 'ASUS NVIDIA GeForce RTX 2070 Super 8GB GDDR6 Graphics Card #2323',
+    sold_date: '2025-06-27T07:00:00.000Z',
+    sold_price: 210
+    },
+    {
+    title: 'ASUS GeForce Dual-RTX 2070-8G GDDR6 Graphics Card 8GB ...Lightly Used',
+    sold_date: '2025-06-27T07:00:00.000Z',
+    sold_price: 159.95
+    },
+    {
+    title: 'Gigabyte GeForce RTX 2070 SUPER Gaming OC 3X 8GB GDDR6 - White',
+    sold_date: '2025-06-27T07:00:00.000Z',
+    sold_price: 180
+    },
+    {
+    title: 'MSI NVIDIA GeForce RTX 2070 8GB GDDR6 Graphics Card (RTX2070ARMOR8G)',
+    sold_date: '2025-06-27T07:00:00.000Z',
+    sold_price: 64
+    },
+    {
+    title: 'ASUS ROG STRIX RTX 2070 SUPER 8GB Graphics Card (ROG-STRIX-RTX2070S-A8G-GAMING)',
+    sold_date: '2025-06-27T07:00:00.000Z',
+    sold_price: 189.99
+    },
+    {
+    title: 'GIGABYTE NVIDIA GeForce RTX 2070 SUPER 8GB GDDR6 Graphics Card ',
+    sold_date: '2025-06-27T07:00:00.000Z',
+    sold_price: 5000
+    }
+]
+
+const outlier_test_listings_key = [
+    {
+    title: 'ASUS GeForce Dual-RTX 2070-8G GDDR6 Graphics Card 8GB ...Lightly Used',
+    sold_date: '2025-06-27T07:00:00.000Z',
+    sold_price: 159.95
+    },
+    {
+    title: 'EVGA NVIDIA GeForce RTX 2070 Super Black 8GB GDDR6 Graphics Card',
+    sold_date: '2025-06-27T07:00:00.000Z',
+    sold_price: 175.79
+    },
+    {
+    title: 'Gigabyte GeForce RTX 2070 SUPER Gaming OC 3X 8GB GDDR6 - White',
+    sold_date: '2025-06-27T07:00:00.000Z',
+    sold_price: 180
+    },
+    {
+    title: 'ASUS ROG STRIX RTX 2070 SUPER 8GB Graphics Card (ROG-STRIX-RTX2070S-A8G-GAMING)',
+    sold_date: '2025-06-27T07:00:00.000Z',
+    sold_price: 189.99
+    },
+    {
+    title: 'ASUS Dual  RTX 2070 SUPER 8GB GDDR6 Graphics Card',
+    sold_date: '2024-11-29T08:00:00.000Z',
+    sold_price: 190
+    },
+    {
+    title: 'MSI NVIDIA GeForce RTX 2070 SUPER ',
+    sold_date: '2025-06-28T07:00:00.000Z',
+    sold_price: 200
+    },
+    {
+        title: 'ASUS NVIDIA GeForce RTX 2070 Super 8GB GDDR6 Graphics Card #2323',
+        sold_date: '2025-06-27T07:00:00.000Z',
+        sold_price: 210
+    },
+    {
+        title: 'ASUS ROG Strix GeForce RTX 2070 OC 08G Gaming Brand New Open Box',
+        sold_date: '2025-06-28T07:00:00.000Z',
+        sold_price: 219.99
+    },
+    {
+    title: 'NVIDIA GeForce RTX 2070 Super GDDR6 Graphics Card - 8GB',
+    sold_date: '2025-06-28T07:00:00.000Z',
+    sold_price: 242.5
+    },
+]
+
+const ebayPriceToNumber_test = () => {
+    const expected_number_1 = 30
+    const test_input_1 = "$20.00 to $40.00"
+    const result_1 = ebayPriceToNumber(test_input_1)
+    const expected_number_2 = 50.32
+    const test_input_2 = "$50.32"
+    const result_2 = ebayPriceToNumber(test_input_2)
+    if (Math.abs(result_1 - expected_number_1) < 0.00005
+        && Math.abs(result_2 - expected_number_2 < 0.00005)) {
+        console.log("ebayPriceToNumber_test: Passed")
+        return true
+    } else {
+        console.log("ebayPriceToNumber_test: Failed")
+        throw new TestError("ebayPriceToNumber_test: Failed")
+    }
+}
+
+const ebayDateToJSDate_test = () => {
+    const expected_date = new Date(`Jun 12, 1971`)
+    const test_input = 'Sold  Jun 12, 1971'
+    const result = ebayDateToJSDate(test_input)
+    // less than 1 millisecond off
+    if (Math.abs(result - expected_date) < 1) {
+        console.log("ebayDateToJSDate_test: Passed")
+        return true
+    } else {
+        console.log("ebayDateToJSDate_test: Failed")
+        throw new TestError("ebayDateToJSDate_test: Failed")
+    }
+}
+
+
+const removePriceOutliers_test = () => {
+    const result = removePriceOutliers(outlier_test_listings)
+    if (result.every) {
+        console.log("removePriceOutliers_test: Passed")
+        return true
+    } else {
+        console.log("removePriceOutliers_test: Failed")
+        throw new TestError("removePriceOutliers_test: Failed")
+    }
+}
+
+const running_tests = async () => {
+    try {
+        ebayPriceToNumber_test()
+        ebayDateToJSDate_test()
+        removePriceOutliers_test()
+    } catch (error) {
+        console.error(error)
+    }
+    process.exit(0)
+}
+
+running_tests()

--- a/server/utils/ebay/EbayScraper.js
+++ b/server/utils/ebay/EbayScraper.js
@@ -51,7 +51,7 @@ const getRecentlySoldListings = async (keyword, page_limit) => {
         })
 
         if (next_page_btn.length === 0) {
-            console.log(`Ran out of pages, pages pulled: ${page_number}`)
+            console.log(`Ran out of pages for ${keyword}, pages pulled: ${page_number}, listings pulled: ${recentlySoldListingsData.length}`)
             break
         }
 

--- a/server/utils/ebay/EbayScraper.js
+++ b/server/utils/ebay/EbayScraper.js
@@ -2,7 +2,7 @@ const JSSoup = require('jssoup').default;
 
 const ebayPriceToNumber = (price) => {
     if (price.includes("to")) {
-        return (Number(price.split(" ")[0].slice(1)) + Number(price.split(" ")[2].slice(1)) / 2)
+        return ((Number(price.split(" ")[0].slice(1)) + Number(price.split(" ")[2].slice(1))) / 2)
     }
     return Number(price.slice(1))
 }
@@ -60,4 +60,4 @@ const getRecentlySoldListings = async (keyword, page_limit) => {
     return recentlySoldListingsData
 }
 
-module.exports = getRecentlySoldListings
+module.exports = { getRecentlySoldListings, ebayDateToJSDate, ebayPriceToNumber }

--- a/server/utils/ebay/EbayScraper.js
+++ b/server/utils/ebay/EbayScraper.js
@@ -40,7 +40,14 @@ const getRecentlySoldListings = async (keyword, page_limit) => {
                 'sold_date': ebayDateToJSDate(ebay_sold_date),
                 'sold_price': ebayPriceToNumber(ebay_sold_price),
             }
-            recentlySoldListingsData.push(listing_data)
+            if (next_page_btn.length === 0) {
+                // If less than a full page of listings, could be related listings, only include title matches
+                if (title.includes(keyword)) {
+                    recentlySoldListingsData.push(listing_data)
+                }
+            } else {
+                recentlySoldListingsData.push(listing_data)
+            }
         })
 
         if (next_page_btn.length === 0) {

--- a/server/utils/ebay/EbayUtils.js
+++ b/server/utils/ebay/EbayUtils.js
@@ -33,4 +33,4 @@ const getListings = async (keyword, limit) => {
     return await response.json()
 }
 
-module.exports = { getListings, getPastListings }
+module.exports = { getListings }

--- a/server/utils/parts/ComparabilityScores.js
+++ b/server/utils/parts/ComparabilityScores.js
@@ -1,5 +1,5 @@
 const ComponentTypes = require('../../models/part_models/ComponentTypesEnum.js')
-const { copy } = require('../../routes/UserRoutes.js')
+const { CPU_PROPERTIES, VIDEOCARD_PROPERTIES, MOTHERBOARD_PROPERTIES, MEMORY_PROPERTIES, HARD_DRIVE_PROPERTIES, POWER_SUPPLY_PROPERTIES, CASE_PROPERTIES} = require('../../models/part_models/ComponentPropertiesEnums.js')
 
 const calcComparabilityScore = (comparable_parts, input_part, specs) => {
     let working_comparable_parts = comparable_parts.map(part => part["_doc"])
@@ -48,37 +48,37 @@ const calcComparabilityScore = (comparable_parts, input_part, specs) => {
 }
 
 const getComparabilityScoresCPUs = (comparable_cpus, input_cpu) => {
-    const specs = ['cores', 'base_clock', 'boost_clock']
+    const specs = [CPU_PROPERTIES.CORES, CPU_PROPERTIES.BASE_CLOCK, CPU_PROPERTIES.BOOST_CLOCK]
     return calcComparabilityScore(comparable_cpus, input_cpu, specs)
 }
 
 const getComparabilityScoresVideoCards = (comparable_videocards, input_videocard) => {
-    const specs = ['vram', 'base_clock', 'boost_clock']
+    const specs = [VIDEOCARD_PROPERTIES.VRAM, VIDEOCARD_PROPERTIES.BASE_CLOCK, VIDEOCARD_PROPERTIES.BOOST_CLOCK]
     return calcComparabilityScore(comparable_videocards, input_videocard, specs)
 }
 
 const getComparabilityScoresMotherboards = (comparable_motherboards, input_motherboard) => {
-    const specs = ['ram_slots', 'max_ram']
+    const specs = [MOTHERBOARD_PROPERTIES.RAM_SLOTS, MOTHERBOARD_PROPERTIES.MAX_RAM]
     return calcComparabilityScore(comparable_motherboards, input_motherboard, specs)
 }
 
 const getComparabilityScoresMemorys = (comparable_memorys, input_memory) => {
-    const specs = ['speed', 'total_size']
+    const specs = [MEMORY_PROPERTIES.SPEED, MEMORY_PROPERTIES.TOTAL_SIZE]
     return calcComparabilityScore(comparable_memorys, input_memory, specs)
 }
 
 const getComparabilityScoresHardDrives = (comparable_hard_drives, input_hard_drive) => {
-    const specs = ['capacity']
+    const specs = [HARD_DRIVE_PROPERTIES.CAPACITY]
     return calcComparabilityScore(comparable_hard_drives, input_hard_drive, specs)
 }
 
 const getComparabilityScoresPowerSupplys = (comparable_power_supplys, input_power_supply) => {
-    const specs = ['wattage']
+    const specs = [POWER_SUPPLY_PROPERTIES.WATTAGE]
     return calcComparabilityScore(comparable_power_supplys, input_power_supply, specs)
 }
 
 const getComparabilityScoresCases = (comparable_cases, input_case) => {
-    const specs = ['internal_bays']
+    const specs = [CASE_PROPERTIES.INTERNAL_BAYS]
     return calcComparabilityScore(comparable_cases, input_case, specs)
 }
 

--- a/server/utils/parts/ComparableParts.js
+++ b/server/utils/parts/ComparableParts.js
@@ -1,4 +1,5 @@
 const ComponentTypes = require('../../models/part_models/ComponentTypesEnum.js')
+const { CPU_PROPERTIES, VIDEOCARD_PROPERTIES, MOTHERBOARD_PROPERTIES, MEMORY_PROPERTIES, HARD_DRIVE_PROPERTIES, POWER_SUPPLY_PROPERTIES, CASE_PROPERTIES} = require('../../models/part_models/ComponentPropertiesEnums.js')
 const CPUModel = require('../../models/part_models/CPUModel.js')
 const VideoCardModel = require('../../models/part_models/VideoCardModel.js')
 const MotherboardModel = require('../../models/part_models/MotherboardModel.js')
@@ -17,14 +18,14 @@ const calcHigh = (value, margin) => {
 }
 
 const getComparableCPUs = async (cpu, margin) => {
-    const comparableCoresLow = calcLow(cpu.cores, margin)
-    const comparableCoresHigh = calcHigh(cpu.cores, margin)
+    const comparableCoresLow = calcLow(cpu[CPU_PROPERTIES.CORES], margin)
+    const comparableCoresHigh = calcHigh(cpu[CPU_PROPERTIES.CORES], margin)
     
-    const comparableBaseClockLow = calcLow(cpu.base_clock, margin)
-    const comparableBaseClockHigh = calcHigh(cpu.base_clock, margin)
+    const comparableBaseClockLow = calcLow(cpu[CPU_PROPERTIES.BASE_CLOCK], margin)
+    const comparableBaseClockHigh = calcHigh(cpu[CPU_PROPERTIES.BASE_CLOCK], margin)
 
-    const comparableBoostClockLow = calcLow(cpu.boost_clock, margin)
-    const comparableBoostClockHigh = calcHigh(cpu.boost_clock, margin)
+    const comparableBoostClockLow = calcLow(cpu[CPU_PROPERTIES.BOOST_CLOCK], margin)
+    const comparableBoostClockHigh = calcHigh(cpu[CPU_PROPERTIES.BOOST_CLOCK], margin)
     
     const comparableCPUs = await CPUModel.find( { 
         $and: [
@@ -41,14 +42,14 @@ const getComparableCPUs = async (cpu, margin) => {
 }
 
 const getComparableVideoCards = async (videocard, margin) => {
-    const comparableVramLow = calcLow(videocard.vram, margin)
-    const comparableVramHigh = calcHigh(videocard.vram, margin)
+    const comparableVramLow = calcLow(videocard[VIDEOCARD_PROPERTIES.VRAM], margin)
+    const comparableVramHigh = calcHigh(videocard[VIDEOCARD_PROPERTIES.VRAM], margin)
     
-    const comparableBaseClockLow = calcLow(videocard.base_clock, margin)
-    const comparableBaseClockHigh = calcHigh(videocard.base_clock, margin)
+    const comparableBaseClockLow = calcLow(videocard[VIDEOCARD_PROPERTIES.BASE_CLOCK], margin)
+    const comparableBaseClockHigh = calcHigh(videocard[VIDEOCARD_PROPERTIES.BASE_CLOCK], margin)
     
-    const comparableBoostClockLow = calcLow(videocard.boost_clock, margin)
-    const comparableBoostClockHigh = calcHigh(videocard.boost_clock, margin)
+    const comparableBoostClockLow = calcLow(videocard[VIDEOCARD_PROPERTIES.BOOST_CLOCK], margin)
+    const comparableBoostClockHigh = calcHigh(videocard[VIDEOCARD_PROPERTIES.BOOST_CLOCK], margin)
     
     const comparableVideoCards = await VideoCardModel.find( { 
         $and: [
@@ -64,11 +65,11 @@ const getComparableVideoCards = async (videocard, margin) => {
 }
 
 const getComparableMotherboards = async (motherboard, margin) => {
-    const comparableRamSlotsLow = calcLow(motherboard.ram_slots, margin)
-    const comparableRamSlotsHigh = calcHigh(motherboard.ram_slots, margin)
+    const comparableRamSlotsLow = calcLow(motherboard[MOTHERBOARD_PROPERTIES.RAM_SLOTS], margin)
+    const comparableRamSlotsHigh = calcHigh(motherboard[MOTHERBOARD_PROPERTIES.RAM_SLOTS], margin)
     
-    const comparableMaxRamLow = calcLow(motherboard.max_ram, margin)
-    const comparableMaxRamHigh = calcHigh(motherboard.max_ram, margin)
+    const comparableMaxRamLow = calcLow(motherboard[MOTHERBOARD_PROPERTIES.MAX_RAM], margin)
+    const comparableMaxRamHigh = calcHigh(motherboard[MOTHERBOARD_PROPERTIES.MAX_RAM], margin)
     
     const comparableMotherboards = await MotherboardModel.find( { 
         $and: [
@@ -84,11 +85,11 @@ const getComparableMotherboards = async (motherboard, margin) => {
 }
 
 const getComparableMemorys = async (memory, margin) => {
-    const comparableSpeedLow = calcLow(memory.speed, margin)
-    const comparableSpeedHigh = calcHigh(memory.speed, margin)
+    const comparableSpeedLow = calcLow(memory[MEMORY_PROPERTIES.SPEED], margin)
+    const comparableSpeedHigh = calcHigh(memory[MEMORY_PROPERTIES.SPEED], margin)
 
-    const comparableTotalSizeLow = calcLow(memory.total_size, margin)
-    const comparableTotalSizeHigh = calcHigh(memory.total_size, margin)
+    const comparableTotalSizeLow = calcLow(memory[MEMORY_PROPERTIES.TOTAL_SIZE], margin)
+    const comparableTotalSizeHigh = calcHigh(memory[MEMORY_PROPERTIES.TOTAL_SIZE], margin)
     
     const comparableMemorys = await MemoryModel.find( { 
         $and: [
@@ -103,8 +104,8 @@ const getComparableMemorys = async (memory, margin) => {
 }
 
 const getComparableHardDrives = async (hard_drive, margin) => {
-    const comparableCapacityLow = calcLow(hard_drive.capacity, margin)
-    const comparableCapacityHigh = calcHigh(hard_drive.capacity, margin)
+    const comparableCapacityLow = calcLow(hard_drive[HARD_DRIVE_PROPERTIES.CAPACITY], margin)
+    const comparableCapacityHigh = calcHigh(hard_drive[HARD_DRIVE_PROPERTIES.CAPACITY], margin)
     
     const comparableHardDrives = await HardDriveModel.find( { 
         $and: [
@@ -119,8 +120,8 @@ const getComparableHardDrives = async (hard_drive, margin) => {
 }
 
 const getComparablePowerSupplys = async (power_supply, margin) => {
-    const comparableWattageLow = calcLow(power_supply.wattage, margin)
-    const comparableWattageHigh = calcHigh(power_supply.wattage, margin)
+    const comparableWattageLow = calcLow(power_supply[POWER_SUPPLY_PROPERTIES.WATTAGE], margin)
+    const comparableWattageHigh = calcHigh(power_supply[POWER_SUPPLY_PROPERTIES.WATTAGE], margin)
     
     const comparablePowerSupplys = await PowerSupplyModel.find( { 
         $and: [
@@ -135,8 +136,8 @@ const getComparablePowerSupplys = async (power_supply, margin) => {
 }
 
 const getComparableCases = async (input_case, margin) => {    
-    const comparableInternalBaysLow = calcLow(input_case.internal_bays, margin)
-    const comparableInternalBaysHigh = calcHigh(input_case.internal_bays, margin)
+    const comparableInternalBaysLow = calcLow(input_case[CASE_PROPERTIES.INTERNAL_BAYS], margin)
+    const comparableInternalBaysHigh = calcHigh(input_case[CASE_PROPERTIES.INTERNAL_BAYS], margin)
 
     const comparableCases = await CaseModel.find( { 
         $and: [

--- a/server/utils/parts/EvaluateParts.js
+++ b/server/utils/parts/EvaluateParts.js
@@ -72,6 +72,7 @@ const grabNMostComparableParts = (comparable_parts, N) => {
 
 const evaluatePart = async (part) => {
     const MINIMUM_LISTINGS = 10
+    const NUM_COMPARABLE_PARTS = 10
     try {
         const comparableParts = await getComparableParts(part)
         if (!comparableParts) {
@@ -95,7 +96,7 @@ const evaluatePart = async (part) => {
 
         const comparablePartsWithListingData = await Promise.all(comparablePartsWithListingDataPromises)
 
-        const mostComparableParts = grabNMostComparableParts(comparablePartsWithListingData, 10)
+        const mostComparableParts = grabNMostComparableParts(comparablePartsWithListingData, NUM_COMPARABLE_PARTS)
 
         // Combine trend analysis results from evaluateComparableParts into trend prediction for input part
     } catch (error) {

--- a/server/utils/parts/EvaluateParts.js
+++ b/server/utils/parts/EvaluateParts.js
@@ -1,5 +1,5 @@
 const { test_cpu } = require('../../tests/parts/test_parts.js')
-const getRecentlySoldListings = require('../ebay/EbayScraper.js')
+const { getRecentlySoldListings } = require('../ebay/EbayScraper.js')
 const { getComparabilityScores } = require('./ComparabilityScores.js')
 const { getComparableParts } = require('./ComparableParts.js')
 
@@ -123,4 +123,4 @@ const evaluatePart = async (part) => {
     }
 }
 
-module.exports = { evaluatePart }
+module.exports = { evaluatePart, removePriceOutliers }

--- a/server/utils/parts/EvaluateParts.js
+++ b/server/utils/parts/EvaluateParts.js
@@ -19,19 +19,55 @@ const grabNRandomItems = (items, N) => {
     return selectedItems
 }
 
+const removePriceOutliers = (listings) => {
+    const listingsSortedByPrice = listings.sort((a, b) => {
+        return a.sold_price - b.sold_price
+    })
+
+    const lower_quartile_index = Math.round(listingsSortedByPrice.length * 0.25)
+    const upper_quartile_index = Math.round(listingsSortedByPrice.length * 0.75)
+    const lower_quartile_price = listingsSortedByPrice[lower_quartile_index].sold_price
+    const upper_quartile_price = listingsSortedByPrice[upper_quartile_index].sold_price
+    const interquartile_range = upper_quartile_price - lower_quartile_price
+
+    const listingsOutliersRemoved = listingsSortedByPrice.filter((listing) => {
+        return !(listing.sold_price > upper_quartile_price + 1.5 * interquartile_range || listing.sold_price < lower_quartile_price - 1.5 * interquartile_range)
+    })
+
+    return listingsOutliersRemoved
+}
 
 const evaluateComparablePart = async (part) => {
     const PAGE_LIMIT = 5
     const recentlySoldListings = await getRecentlySoldListings(part.model, PAGE_LIMIT)
+    const recentlySoldListingsOutliersRemoved = removePriceOutliers(recentlySoldListings)
+    console.log(recentlySoldListingsOutliersRemoved)
 
-    // Insert analysis of listing prices to find trends
+
+
+    if (recentlySoldListings.length < 10) {
+        return false
+    }
+
+
+
 
 }
 
 const evaluatePart = async (part) => {
     const comparableParts = await getComparableParts(part)
-
     const comparablePartsWithComparabilityScores = getComparabilityScores(comparableParts, part)
+
+    const evaluatedComparablePartsPromises = [comparablePartsWithComparabilityScores[0]].map( async (comparable_part) => {
+        const evaluated_comparable_part = await evaluateComparablePart(comparable_part)
+        if (evaluated_comparable_part) {
+
+        }
+    })
+
+    const resolvedEvaluatedComparablePartsPromises = await Promise.all(evaluatedComparablePartsPromises)
+
+
 
 
     // Combine trend analysis results from evaluateComparableParts into trend prediction for input part

--- a/server/utils/parts/EvaluateParts.js
+++ b/server/utils/parts/EvaluateParts.js
@@ -70,6 +70,24 @@ const grabNMostComparableParts = (comparable_parts, N) => {
     }
 }
 
+const calcWeightedLineOfBestFit = (comparable_parts) => {
+    let sum_prices = 0
+    let sum_times = 0
+    let num_prices = 0
+    let num_times = 0
+    comparable_parts.map( (comparable_part) => {
+        comparable_part.listing_data.map( (listing) => {
+            sum_prices += listing.sold_price * comparable_part.average_comparability_score
+            sum_times += listing.sold_date * comparable_part.average_comparability_score
+            num_prices += 1 * comparable_part.average_comparability_score
+            num_times += 1 * comparable_part.average_comparability_score
+        })
+    })
+    const weighted_avg_price = sum_prices / num_prices
+    const weighted_avg_time = sum_times / num_times
+
+}
+
 const evaluatePart = async (part) => {
     const MINIMUM_LISTINGS = 10
     const NUM_COMPARABLE_PARTS = 10
@@ -98,7 +116,8 @@ const evaluatePart = async (part) => {
 
         const mostComparableParts = grabNMostComparableParts(comparablePartsWithListingData, NUM_COMPARABLE_PARTS)
 
-        // Combine trend analysis results from evaluateComparableParts into trend prediction for input part
+
+
     } catch (error) {
         console.log(error)
     }


### PR DESCRIPTION
### Summary
PR includes several improvements to listing evaluation and data cleaning
Fixed ebayPriceToNumber helper function failing on prices formatted like $xx.xx to $xx.xx, instead it averages the two ends for the midpoint
Fixed EbayScraper.js pulling related listings for obscure parts resulting in bad data, requires direct title match for listings on the last page of data
Fixed outliers (usually from bulk deals of multiple components) by implementing IQR (interquartile range) based checks to remove outliers
Added a MINIMUM_LISTINGS const to determine how many listings are required for a comparable part to be represented
Added a NUM_COMPARABLE_PARTS and a grabNMostComparableParts helper function to only grab the NUM_COMPARABLE_PARTS most comparable parts ranked on average comparability score
### Tests
|ebayPriceToNumber_test|ebayDateToJSDate_test|removePriceOutliers_test|
|---|---|---|
|Testing with "$20.00 to $40.00" and "$50.32"|Testing with "Sold  Jun 12, 1971"|Testing with high and low outliers|

|Test Results|
|---|
|<img width="240" alt="image" src="https://github.com/user-attachments/assets/62a6a323-a8ab-452a-88ba-6e7ce4b6bd02" />|
