### PR TITLE
[builds][express][1/x] Added PopulatePrices, Improved EbayScraper

### DIFF
--- a/server/models/part_models/CPUModel.js
+++ b/server/models/part_models/CPUModel.js
@@ -9,6 +9,9 @@ const CPUSchema = new mongoose.Schema({
     boost_clock: Number,
     integrated_graphics: String,
     multithreading: Boolean,
+    thirtyDayAverage: Number,
+    thirtyDayTime: Number,
+    thirtyDayListingCount: Number,
 })
 
 const CPUModel = mongoose.model('CPU', CPUSchema, 'cpu')

--- a/server/models/part_models/CaseModel.js
+++ b/server/models/part_models/CaseModel.js
@@ -10,6 +10,9 @@ const CaseSchema = new mongoose.Schema({
     internal_bays: Number,
     psu_wattage: Number,
     side_panel: String,
+    thirtyDayAverage: Number,
+    thirtyDayTime: Number,
+    thirtyDayListingCount: Number,
 })
 
 const CaseModel = mongoose.model('Case', CaseSchema, 'case')

--- a/server/models/part_models/HardDriveModel.js
+++ b/server/models/part_models/HardDriveModel.js
@@ -9,6 +9,9 @@ const HardDriveSchema = new mongoose.Schema({
     storage_type: String,
     form_factor: String,
     interface: String,
+    thirtyDayAverage: Number,
+    thirtyDayTime: Number,
+    thirtyDayListingCount: Number,
 })
 
 const HardDriveModel = mongoose.model('HardDrive', HardDriveSchema, 'hard-drive')

--- a/server/models/part_models/MemoryModel.js
+++ b/server/models/part_models/MemoryModel.js
@@ -12,6 +12,9 @@ const MemorySchema = new mongoose.Schema({
     first_word_latency: Number,
     cas_timing: Number,
     price_per_gb: Number,
+    thirtyDayAverage: Number,
+    thirtyDayTime: Number,
+    thirtyDayListingCount: Number,
 })
 
 const MemoryModel = mongoose.model('Memory', MemorySchema, 'memory')

--- a/server/models/part_models/MotherboardModel.js
+++ b/server/models/part_models/MotherboardModel.js
@@ -8,6 +8,9 @@ const MotherboardSchema = new mongoose.Schema({
     form_factor: String,
     ram_slots: Number,
     max_ram: Number,
+    thirtyDayAverage: Number,
+    thirtyDayTime: Number,
+    thirtyDayListingCount: Number,
 })
 
 const MotherboardModel = mongoose.model('Motherboard', MotherboardSchema, 'motherboard')

--- a/server/models/part_models/PowerSupplyModel.js
+++ b/server/models/part_models/PowerSupplyModel.js
@@ -8,6 +8,9 @@ const PowerSupplySchema = new mongoose.Schema({
     efficiency_rating: String,
     wattage: Number,
     modular: String,
+    thirtyDayAverage: Number,
+    thirtyDayTime: Number,
+    thirtyDayListingCount: Number,
 })
 
 const PowerSupplyModel = mongoose.model('PowerSupply', PowerSupplySchema, 'power-supply')

--- a/server/models/part_models/VideoCardModel.js
+++ b/server/models/part_models/VideoCardModel.js
@@ -8,6 +8,9 @@ const VideoCardSchema = new mongoose.Schema({
     boost_clock: Number,
     vram: Number,
     chipset: String,
+    thirtyDayAverage: Number,
+    thirtyDayTime: Number,
+    thirtyDayListingCount: Number,
 })
 
 const VideoCardModel = mongoose.model('VideoCard', VideoCardSchema, 'video-card')

--- a/server/utils/builds/BuildRecommender.js
+++ b/server/utils/builds/BuildRecommender.js
@@ -1,0 +1,4 @@
+
+
+
+module.exports = { BuildRecommender }

--- a/server/utils/builds/PopulatePrices.js
+++ b/server/utils/builds/PopulatePrices.js
@@ -10,9 +10,10 @@ const { removeIntraPriceOutliers } = require('../parts/EvaluatePart.js')
 
 const MODELS = [CPUModel, VideoCardModel, MotherboardModel, MemoryModel, HardDriveModel, PowerSupplyModel, CaseModel]
 
+const LISTING_DAY_AGE_LIMIT = 30
+const MAX_LISTING_LIMIT = 100
+
 const populatePrices = async (models, prev_listing_limit) => {
-    const DAY_LIMIT = 30
-    const MAX_LISTING_LIMIT = 100
     for(let model of models) {
         console.log(`Populating ${model.collection.collectionName}`)
         let part_count = 0
@@ -27,7 +28,7 @@ const populatePrices = async (models, prev_listing_limit) => {
             }
             part_count += 1
             const keyword = part.brand + ' ' + part.model
-            const listingData = await getRecentlySoldListings(keyword, DAY_LIMIT, MAX_LISTING_LIMIT)
+            const listingData = await getRecentlySoldListings(keyword, LISTING_DAY_AGE_LIMIT, MAX_LISTING_LIMIT)
             if (listingData.length < 4) {
                 part.thirtyDayAverage = -1
                 part.thirtyDayTime = new Date().getTime()

--- a/server/utils/builds/PopulatePrices.js
+++ b/server/utils/builds/PopulatePrices.js
@@ -1,0 +1,61 @@
+const mongoose = require('../../Mongoose.js')
+const CPUModel = require('../../models/part_models/CPUModel.js')
+const VideoCardModel = require('../../models/part_models/VideoCardModel.js')
+const MotherboardModel = require('../../models/part_models/MotherboardModel.js')
+const MemoryModel = require('../../models/part_models/MemoryModel.js')
+const HardDriveModel = require('../../models/part_models/HardDriveModel.js')
+const PowerSupplyModel = require('../../models/part_models/PowerSupplyModel.js')
+const CaseModel = require('../../models/part_models/CaseModel.js')
+const { getRecentlySoldListings } = require('../ebay/EbayScraper.js')
+const { model } = require('mongoose')
+const { removeIntraPriceOutliers } = require('../parts/EvaluatePart.js')
+
+const MODELS = [CPUModel, VideoCardModel, MotherboardModel, MemoryModel, HardDriveModel, PowerSupplyModel, CaseModel]
+
+const populatePrices = async (models, listing_limit) => {
+    for(let model of models) {
+        console.log(`Populating ${model.collection.collectionName}`)
+        let part_count = 0
+        let total_listing_count = 0
+        const parts = await model.find()
+        for (let part of parts) {
+            if(part.thirtyDayTime !== 0) {
+                continue
+            }
+            if (!(part.thirtyDayListingCount >= listing_limit)) {
+                continue
+            }
+            part_count += 1
+            const DAY_LIMIT = 30
+            const LISTING_LIMIT = 100
+            const keyword = part.brand + ' ' + part.model
+            const listingData = await getRecentlySoldListings(keyword, DAY_LIMIT, LISTING_LIMIT)
+            if (listingData.length < 4) {
+                part.thirtyDayAverage = -1
+                part.thirtyDayTime = new Date().getTime()
+                part.thirtyDayListingCount = listingData.length
+                await part.save()
+                continue
+            }
+            const listingDataPriceOutliersRemoved = removeIntraPriceOutliers(listingData)
+            let price_sum = 0
+            let price_count = 0
+            listingDataPriceOutliersRemoved.map( (listing) => {
+                price_sum += listing.sold_price
+                price_count += 1
+            })
+            let thirtyDayAverage = 0
+            if (!(listingDataPriceOutliersRemoved.length === 0)) {
+                thirtyDayAverage = Math.round(price_sum / price_count * 100) / 100
+            }
+            part.thirtyDayAverage = thirtyDayAverage
+            part.thirtyDayTime = new Date().getTime()
+            part.thirtyDayListingCount = listingDataPriceOutliersRemoved.length
+            await part.save()
+            total_listing_count += listingDataPriceOutliersRemoved.length
+        }
+        console.log(`Finished populating ${model.collection.collectionName} with ${part_count} parts and ${total_listing_count} listings`)
+    }
+}
+
+populatePrices(MODELS, 0)

--- a/server/utils/ebay/EbayScraper.js
+++ b/server/utils/ebay/EbayScraper.js
@@ -29,7 +29,7 @@ const getRecentlySoldListings = async (keyword, day_limit, listing_limit) => {
         const soup = new JSSoup(html_text)
 
         const next_page_btn = soup.findAll('a', 'pagination__next')
-
+        // First two s-item__info class divs are used to display options at top of listings page
         const recentlySoldListings = soup.findAll('div', 's-item__info')?.slice(2)
         recentlySoldListings?.every( (listing) => {
             if (recentlySoldListingsData.length >= listing_limit) {

--- a/server/utils/ebay/EbayScraper.js
+++ b/server/utils/ebay/EbayScraper.js
@@ -16,57 +16,62 @@ const ebayDateToJSDate = (ebay_date) => {
 }
 
 const getRecentlySoldListings = async (keyword, day_limit, listing_limit) => {
-    let page_number = 1
-    const TIME_LIMIT_IN_MILLISECONDS = day_limit * 24 * 60 * 60 * 1000
+    try {
+        let page_number = 1
+        const TIME_LIMIT_IN_MILLISECONDS = day_limit * 24 * 60 * 60 * 1000
 
-    let recentlySoldListingsData = []
-    let scrape = true
-    while (scrape) {
-        const url = `https://www.ebay.com/sch/i.html?_nkw=${keyword}&_sacat=0&_from=R40&rt=nc&LH_Sold=1&LH_Complete=1&_pgn=${page_number}`
-        const response = await fetch(url, {method: 'GET',})
-        const html_text = await response.text()
+        let recentlySoldListingsData = []
+        let scrape = true
+        while (scrape) {
+            const url = `https://www.ebay.com/sch/i.html?_nkw=${keyword}&_sacat=0&_from=R40&rt=nc&LH_Sold=1&LH_Complete=1&_pgn=${page_number}`
+            const response = await fetch(url, {method: 'GET',})
+            const html_text = await response.text()
 
-        const soup = new JSSoup(html_text)
+            const soup = new JSSoup(html_text)
 
-        const next_page_btn = soup.findAll('a', 'pagination__next')
-        // First two s-item__info class divs are used to display options at top of listings page
-        const recentlySoldListings = soup.findAll('div', 's-item__info')?.slice(2)
-        recentlySoldListings?.every( (listing) => {
-            if (recentlySoldListingsData.length >= listing_limit) {
+            const next_page_btn = soup.findAll('a', 'pagination__next')
+            // First two s-item__info class divs are used to display options at top of listings page
+            const recentlySoldListings = soup.findAll('div', 's-item__info')?.slice(2)
+            recentlySoldListings?.every( (listing) => {
+                if (recentlySoldListingsData.length >= listing_limit) {
+                    scrape = false
+                    return false
+                }
+                const title = listing?.find('div', 's-item__title')?.find('span')?.text
+                const ebay_sold_date = listing?.find('span', 's-item__caption--signal')?.text
+                const ebay_sold_price = listing?.find('span', 's-item__price')?.text
+                if (!title || !ebay_sold_date || !ebay_sold_price) {
+                    return
+                }
+                const listing_data = {
+                    'title': title,
+                    'sold_date': ebayDateToJSDate(ebay_sold_date),
+                    'sold_price': ebayPriceToNumber(ebay_sold_price),
+                }
+                // Skip listing if it's more than 3 months old
+                // If less than a full page of listings, could be related listings, only include title matches
+                if (!(ebayDateToJSDate(ebay_sold_date) < ((new Date()).getTime() - TIME_LIMIT_IN_MILLISECONDS))
+                        && !(isNaN(listing_data.sold_price))
+                        && (next_page_btn.length > 0 || title.includes(keyword))) {
+                    recentlySoldListingsData.push(listing_data)
+                    return true
+                }
+            })
+
+            if (!scrape) {
+                console.log(`Hit listing limit for ${keyword}, pages pulled: ${page_number}, listings pulled: ${recentlySoldListingsData.length}`)
+            } else if (next_page_btn.length === 0) {
+                console.log(`Ran out of pages for ${keyword}, pages pulled: ${page_number}, listings pulled: ${recentlySoldListingsData.length}`)
                 scrape = false
-                return false
             }
-            const title = listing?.find('div', 's-item__title')?.find('span')?.text
-            const ebay_sold_date = listing?.find('span', 's-item__caption--signal')?.text
-            const ebay_sold_price = listing?.find('span', 's-item__price')?.text
-            if (!title || !ebay_sold_date || !ebay_sold_price) {
-                return
-            }
-            const listing_data = {
-                'title': title,
-                'sold_date': ebayDateToJSDate(ebay_sold_date),
-                'sold_price': ebayPriceToNumber(ebay_sold_price),
-            }
-            // Skip listing if it's more than 3 months old
-            // If less than a full page of listings, could be related listings, only include title matches
-            if (!(ebayDateToJSDate(ebay_sold_date) < ((new Date()).getTime() - TIME_LIMIT_IN_MILLISECONDS))
-                    && !(isNaN(listing_data.sold_price))
-                    && (next_page_btn.length > 0 || title.includes(keyword))) {
-                recentlySoldListingsData.push(listing_data)
-                return true
-            }
-        })
 
-        if (!scrape) {
-            console.log(`Hit listing limit for ${keyword}, pages pulled: ${page_number}, listings pulled: ${recentlySoldListingsData.length}`)
-        } else if (next_page_btn.length === 0) {
-            console.log(`Ran out of pages for ${keyword}, pages pulled: ${page_number}, listings pulled: ${recentlySoldListingsData.length}`)
-            scrape = false
+            page_number++
         }
-
-        page_number++
+        return recentlySoldListingsData
+    } catch (error) {
+        console.error(error)
+        throw error
     }
-    return recentlySoldListingsData
 }
 
 module.exports = { getRecentlySoldListings, ebayDateToJSDate, ebayPriceToNumber }

--- a/server/utils/parts/EvaluatePart.js
+++ b/server/utils/parts/EvaluatePart.js
@@ -3,6 +3,10 @@ const { getRecentlySoldListings } = require('../ebay/EbayScraper.js')
 const { getComparabilityScores } = require('./ComparabilityScores.js')
 const { getComparableParts } = require('./ComparableParts.js')
 
+const MINIMUM_LISTINGS = 10
+const LISTING_DAY_AGE_LIMIT = 90
+const MAX_LISTING_LIMIT = 500
+
 const calcQuartileInfo = (listings) => {
     const listingsSortedByPrice = listings.sort((a, b) => {
         return a.sold_price - b.sold_price
@@ -51,10 +55,8 @@ const removeInterPriceOutliers = (comparable_parts) => {
 }
 
 const getListingData = async (part) => {
-    const DAY_LIMIT = 90
-    const MAX_LISTING_LIMIT = 500
     const keyword = part.brand + ' ' + part.model
-    const recentlySoldListings = await getRecentlySoldListings(keyword, DAY_LIMIT, MAX_LISTING_LIMIT)
+    const recentlySoldListings = await getRecentlySoldListings(keyword, LISTING_DAY_AGE_LIMIT, MAX_LISTING_LIMIT)
     if (recentlySoldListings.length === 0) {
         return []
     }
@@ -88,7 +90,6 @@ const grabNMostComparableParts = (comparable_parts, N) => {
 }
 
 const evaluatePart = async (part) => {
-    const MINIMUM_LISTINGS = 10
     const comparableParts = await getComparableParts(part)
     if (!comparableParts) {
         throw new PartEvaluationError("No comparable parts found!")

--- a/server/utils/parts/EvaluatePart.js
+++ b/server/utils/parts/EvaluatePart.js
@@ -52,8 +52,10 @@ const removeInterPriceOutliers = (comparable_parts) => {
 }
 
 const getListingData = async (part) => {
-    const PAGE_LIMIT = 5
-    const recentlySoldListings = await getRecentlySoldListings(part.model, PAGE_LIMIT)
+    const DAY_LIMIT = 90
+    const LISTING_LIMIT = 100
+    const keyword = part.brand + ' ' + part.model
+    const recentlySoldListings = await getRecentlySoldListings(keyword, DAY_LIMIT, LISTING_LIMIT)
     if (recentlySoldListings.length === 0) {
         return []
     }

--- a/server/utils/parts/EvaluatePart.js
+++ b/server/utils/parts/EvaluatePart.js
@@ -22,7 +22,6 @@ const calcQuartileInfo = (listings) => {
 
 const removeIntraPriceOutliers = (listings) => {
     const { lower_quartile_price, upper_quartile_price, interquartile_range } = calcQuartileInfo(listings)
-
     const listingsOutliersRemoved = listings.filter((listing) => {
         return !(listing.sold_price > upper_quartile_price + 1.5 * interquartile_range || listing.sold_price < lower_quartile_price - 1.5 * interquartile_range)
     })

--- a/server/utils/parts/EvaluatePart.js
+++ b/server/utils/parts/EvaluatePart.js
@@ -52,9 +52,9 @@ const removeInterPriceOutliers = (comparable_parts) => {
 
 const getListingData = async (part) => {
     const DAY_LIMIT = 90
-    const LISTING_LIMIT = 100
+    const MAX_LISTING_LIMIT = 500
     const keyword = part.brand + ' ' + part.model
-    const recentlySoldListings = await getRecentlySoldListings(keyword, DAY_LIMIT, LISTING_LIMIT)
+    const recentlySoldListings = await getRecentlySoldListings(keyword, DAY_LIMIT, MAX_LISTING_LIMIT)
     if (recentlySoldListings.length === 0) {
         return []
     }

--- a/server/utils/pcpartpicker/populate.py
+++ b/server/utils/pcpartpicker/populate.py
@@ -28,6 +28,9 @@ def populate_cpus():
             "cores": cpu.cores,
             "base_clock": cpu.base_clock.cycles,
             "multithreading": cpu.multithreading,
+            "thirtyDayAverage": 0,
+            "thirtyDayTime": 0,
+            "thirtyDayListingCount": 0,
         }
 
         # Uses base_clock as boost_clock if no boost_clock
@@ -56,10 +59,13 @@ def populate_video_cards():
     for videocard in videocard_data:
         videocard_doc = {
             "type": "video-card",
-            "model": videocard.model,
+            "model": videocard.model + ' ' + videocard.chipset,
             "brand": videocard.brand,
             "chipset": videocard.chipset,
             "vram": videocard.vram.total,
+            "thirtyDayAverage": 0,
+            "thirtyDayTime": 0,
+            "thirtyDayListingCount": 0,
         }
 
         # Set base_clock to 0 if not given
@@ -95,6 +101,9 @@ def populate_motherboards():
             "form_factor": motherboard.form_factor,
             "ram_slots": motherboard.ram_slots,
             "max_ram": motherboard.max_ram.total,
+            "thirtyDayAverage": 0,
+            "thirtyDayTime": 0,
+            "thirtyDayListingCount": 0,
         }
 
         motherboard_count += 1
@@ -121,6 +130,9 @@ def populate_memorys():
             "first_word_latency": memory.first_word_latency,
             "cas_timing": memory.cas_timing,
             "price_per_gb": float(memory.price_per_gb.amount),
+            "thirtyDayAverage": 0,
+            "thirtyDayTime": 0,
+            "thirtyDayListingCount": 0,
         }
 
         memory_count += 1
@@ -144,6 +156,9 @@ def populate_hard_drives():
             "storage_type": hard_drive.storage_type,
             "form_factor": hard_drive.form_factor,
             "interface": hard_drive.interface,
+            "thirtyDayAverage": 0,
+            "thirtyDayTime": 0,
+            "thirtyDayListingCount": 0,
         }
 
         if hard_drive.platter_rpm:
@@ -177,6 +192,9 @@ def populate_power_supplys():
             "efficiency_rating": power_supply.efficiency_rating,
             "wattage": power_supply.wattage,
             "modular": power_supply.modular,
+            "thirtyDayAverage": 0,
+            "thirtyDayTime": 0,
+            "thirtyDayListingCount": 0,
         }
 
         power_supply_count += 1
@@ -199,6 +217,9 @@ def populate_cases():
             "color": case.color,
             "external_bays": case.external_bays,
             "internal_bays": case.internal_bays,
+            "thirtyDayAverage": 0,
+            "thirtyDayTime": 0,
+            "thirtyDayListingCount": 0,
         }
 
         if case.psu_wattage:


### PR DESCRIPTION
### Summary
Added populatePrices(models, listing_limit) to populate database components with:
thirtyDayAverage price - average price from listings in the last thirty days
thirtyDayTime - indicating when the thirtyDayAverage was calculated
thirtyDayListingCount - indicating how many listings were pulled to calculate the last thirtyDayAverage price
listing_limit - when running populatePrice, it skips models with a thirtyDayListingCount < listing_limit (since 2/3 of parts in database have no recent listing data, it ensures that they aren't scraped every time)

Improved EbayScraper:
Added day_limit parameter replacing previous hard coded 90 day time limit for listing retrieval
Replaced page_limit with listing_limit (instead of x amount of pages, x amount of listings will be pulled before stopping)

### Data Models:
Added thirtyDayAverage, thirtyDayTime, and thirtyDayListingCount to each component data model
Changed video-card 'model' property to be model + ' ' + chipset for more accurate listings

### Tests
|thirtyDayAverage, thirtyDayTime, thirtyDayListingCount with found listings >= listing_limit|
|---|
|<img width="383" alt="image" src="https://github.com/user-attachments/assets/894872c3-dfdd-4d75-bd69-12141809331d" />|

|thirtyDayAverage, thirtyDayTime, thirtyDayListingCount with found listings < listing_limit|
|---|
|<img width="398" alt="image" src="https://github.com/user-attachments/assets/a1c3f5b8-87c4-4009-93c3-c22d89031278" />|

|Video-Card Scatter Chart w/ out chipset in keyword|Video-Card Scatter Chart w/ chipset in keyword|
|---|---|
|![image](https://github.com/user-attachments/assets/a7caca52-a9b7-4f36-afad-5926f2ba7bb3)|![image](https://github.com/user-attachments/assets/41af2284-e0c8-46ce-b5a2-89424f51120d)|